### PR TITLE
add self intersection test

### DIFF
--- a/include/fcpw/aggregates/sbvh.h
+++ b/include/fcpw/aggregates/sbvh.h
@@ -25,6 +25,8 @@ struct SbvhNode {
 		int secondChildOffset;
 	};
 	int nReferences;
+
+	bool isLeaf() const { return nReferences; }
 };
 
 struct BvhTraversal {
@@ -71,6 +73,11 @@ public:
 	bool findClosestPointFromNode(BoundingSphere<DIM>& s, Interaction<DIM>& i,
 								  int nodeStartIndex, int aggregateIndex,
 								  const Vector<DIM>& boundaryHint, int& nodesVisited) const;
+
+	bool isSelfintersecting(int nodeStartIndex, int aggregateIndex) const;
+
+	template<class F>
+	void intersectRecursive(F& f, int nodeIdx1, int depth1, int nodeIdx2, int depth2) const;
 
 protected:
 	// computes split cost based on heuristic
@@ -122,6 +129,8 @@ protected:
 	std::vector<PrimitiveType *>& primitives;
 	std::vector<SbvhNode<DIM>> flatTree;
 	bool packLeaves, primitiveTypeIsAggregate;
+
+	mutable bool foundSelfIntersection;
 
 	template<size_t U, size_t V, typename W>
 	friend class Mbvh;

--- a/include/fcpw/core/primitive.h
+++ b/include/fcpw/core/primitive.h
@@ -84,6 +84,8 @@ public:
 		return this->findClosestPointFromNode(s, i, 0, this->index, Vector<DIM>::Zero(), nodesVisited);
 	}
 
+	bool isSelfintersecting() { return this->isSelfintersecting(0, this->index); }
+
 	// performs inside outside test for x
 	// NOTE: assumes aggregate bounds watertight shape
 	bool contains(const Vector<DIM>& x, bool useRayIntersection=true) const {
@@ -155,6 +157,8 @@ public:
 	virtual bool findClosestPointFromNode(BoundingSphere<DIM>& s, Interaction<DIM>& i,
 										  int nodeStartIndex, int aggregateIndex,
 										  const Vector<DIM>& boundaryHint, int& nodesVisited) const = 0;
+
+	virtual bool isSelfintersecting(int nodeStartIndex, int aggregateIndex) const { return true; }
 
 	// members
 	int index;

--- a/include/fcpw/fcpw.h
+++ b/include/fcpw/fcpw.h
@@ -99,6 +99,8 @@ public:
 	// returns a pointer to the underlying scene data; use at your own risk...
 	SceneData<DIM>* getSceneData();
 
+	bool isSelfintersecting();
+
 private:
 	// member
 	std::unique_ptr<SceneData<DIM>> sceneData;

--- a/include/fcpw/fcpw.inl
+++ b/include/fcpw/fcpw.inl
@@ -663,4 +663,11 @@ inline SceneData<DIM>* Scene<DIM>::getSceneData()
 	return sceneData.get();
 }
 
+template<size_t DIM>
+inline bool Scene<DIM>::isSelfintersecting() 
+{
+	return sceneData->aggregate->isSelfintersecting();
+}
+	
+
 } // namespace fcpw

--- a/include/fcpw/utilities/intersection.h
+++ b/include/fcpw/utilities/intersection.h
@@ -1,0 +1,587 @@
+/*
+*
+*  Triangle-Triangle Overlap Test Routines
+*  July, 2002
+*  Updated December 2003
+*
+*  This file contains C implementation of algorithms for
+*  performing two and three-dimensional triangle-triangle intersection test
+*  The algorithms and underlying theory are described in
+*
+* "Fast and Robust Triangle-Triangle Overlap Test
+*  Using Orientation Predicates"  P. Guigue - O. Devillers
+*
+*  Journal of Graphics Tools, 8(1), 2003
+*
+*  Several geometric predicates are defined.  Their parameters are all
+*  points.  Each point is an array of two or three double precision
+*  floating point numbers. The geometric predicates implemented in
+*  this file are:
+*
+*    int tri_tri_overlap_test_3d(p1,q1,r1,p2,q2,r2)
+*    int tri_tri_overlap_test_2d(p1,q1,r1,p2,q2,r2)
+*
+*    int tri_tri_intersection_test_3d(p1,q1,r1,p2,q2,r2,
+*                                     coplanar,source,target)
+*
+*       is a version that computes the segment of intersection when
+*       the triangles overlap (and are not coplanar)
+*
+*    each function returns 1 if the triangles (including their
+*    boundary) intersect, otherwise 0
+*
+*
+*  Other information are available from the Web page
+*  http://www.acm.org/jgt/papers/GuigueDevillers03/
+*
+*/
+
+
+/* function prototype */
+
+// Three-dimensional Triangle-Triangle Overlap Test
+int tri_tri_overlap_test_3d(double p1[3], double q1[3], double r1[3],
+    double p2[3], double q2[3], double r2[3]);
+
+
+// Three-dimensional Triangle-Triangle Overlap Test
+// additionaly computes the segment of intersection of the two triangles if it exists. 
+// coplanar returns whether the triangles are coplanar, 
+// source and target are the endpoints of the line segment of intersection 
+int tri_tri_intersection_test_3d(double p1[3], double q1[3], double r1[3],
+    double p2[3], double q2[3], double r2[3],
+    int* coplanar,
+    double source[3], double target[3]);
+
+
+int coplanar_tri_tri3d(double  p1[3], double  q1[3], double  r1[3],
+    double  p2[3], double  q2[3], double  r2[3],
+    double  N1[3]);
+
+
+// Two dimensional Triangle-Triangle Overlap Test
+int tri_tri_overlap_test_2d(double p1[2], double q1[2], double r1[2],
+    double p2[2], double q2[2], double r2[2]);
+
+
+
+
+
+
+/* some 3D macros */
+
+#define CROSS(dest,v1,v2)                       \
+               dest[0]=v1[1]*v2[2]-v1[2]*v2[1]; \
+               dest[1]=v1[2]*v2[0]-v1[0]*v2[2]; \
+               dest[2]=v1[0]*v2[1]-v1[1]*v2[0];
+
+#define DOT(v1,v2) (v1[0]*v2[0]+v1[1]*v2[1]+v1[2]*v2[2])
+
+
+
+#define SUB(dest,v1,v2) dest[0]=v1[0]-v2[0]; \
+                        dest[1]=v1[1]-v2[1]; \
+                        dest[2]=v1[2]-v2[2]; 
+
+
+#define SCALAR(dest,alpha,v) dest[0] = alpha * v[0]; \
+                             dest[1] = alpha * v[1]; \
+                             dest[2] = alpha * v[2];
+
+
+
+#define CHECK_MIN_MAX(p1,q1,r1,p2,q2,r2) {\
+  SUB(v1,p2,q1)\
+  SUB(v2,p1,q1)\
+  CROSS(N1,v1,v2)\
+  SUB(v1,q2,q1)\
+  if (DOT(v1,N1) > 0.0f) return 0;\
+  SUB(v1,p2,p1)\
+  SUB(v2,r1,p1)\
+  CROSS(N1,v1,v2)\
+  SUB(v1,r2,p1) \
+  if (DOT(v1,N1) > 0.0f) return 0;\
+  else return 1; }
+
+
+
+/* Permutation in a canonical form of T2's vertices */
+
+#define TRI_TRI_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2) { \
+  if (dp2 > 0.0f) { \
+     if (dq2 > 0.0f) CHECK_MIN_MAX(p1,r1,q1,r2,p2,q2) \
+     else if (dr2 > 0.0f) CHECK_MIN_MAX(p1,r1,q1,q2,r2,p2)\
+     else CHECK_MIN_MAX(p1,q1,r1,p2,q2,r2) }\
+  else if (dp2 < 0.0f) { \
+    if (dq2 < 0.0f) CHECK_MIN_MAX(p1,q1,r1,r2,p2,q2)\
+    else if (dr2 < 0.0f) CHECK_MIN_MAX(p1,q1,r1,q2,r2,p2)\
+    else CHECK_MIN_MAX(p1,r1,q1,p2,q2,r2)\
+  } else { \
+    if (dq2 < 0.0f) { \
+      if (dr2 >= 0.0f)  CHECK_MIN_MAX(p1,r1,q1,q2,r2,p2)\
+      else CHECK_MIN_MAX(p1,q1,r1,p2,q2,r2)\
+    } \
+    else if (dq2 > 0.0f) { \
+      if (dr2 > 0.0f) CHECK_MIN_MAX(p1,r1,q1,p2,q2,r2)\
+      else  CHECK_MIN_MAX(p1,q1,r1,q2,r2,p2)\
+    } \
+    else  { \
+      if (dr2 > 0.0f) CHECK_MIN_MAX(p1,q1,r1,r2,p2,q2)\
+      else if (dr2 < 0.0f) CHECK_MIN_MAX(p1,r1,q1,r2,p2,q2)\
+      else return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1);\
+     }}}
+
+
+
+/*
+*
+*  Three-dimensional Triangle-Triangle Overlap Test
+*
+*/
+
+
+int tri_tri_overlap_test_3d(double p1[3], double q1[3], double r1[3],
+
+    double p2[3], double q2[3], double r2[3])
+{
+    double dp1, dq1, dr1, dp2, dq2, dr2;
+    double v1[3], v2[3];
+    double N1[3], N2[3];
+
+    /* Compute distance signs  of p1, q1 and r1 to the plane of
+       triangle(p2,q2,r2) */
+
+
+    SUB(v1, p2, r2)
+        SUB(v2, q2, r2)
+        CROSS(N2, v1, v2)
+
+        SUB(v1, p1, r2)
+        dp1 = DOT(v1, N2);
+    SUB(v1, q1, r2)
+        dq1 = DOT(v1, N2);
+    SUB(v1, r1, r2)
+        dr1 = DOT(v1, N2);
+
+    if (((dp1 * dq1) > 0.0f) && ((dp1 * dr1) > 0.0f))  return 0;
+
+    /* Compute distance signs  of p2, q2 and r2 to the plane of
+       triangle(p1,q1,r1) */
+
+
+    SUB(v1, q1, p1)
+        SUB(v2, r1, p1)
+        CROSS(N1, v1, v2)
+
+        SUB(v1, p2, r1)
+        dp2 = DOT(v1, N1);
+    SUB(v1, q2, r1)
+        dq2 = DOT(v1, N1);
+    SUB(v1, r2, r1)
+        dr2 = DOT(v1, N1);
+
+    if (((dp2 * dq2) > 0.0f) && ((dp2 * dr2) > 0.0f)) return 0;
+
+    /* Permutation in a canonical form of T1's vertices */
+
+
+    if (dp1 > 0.0f) {
+        if (dq1 > 0.0f) TRI_TRI_3D(r1, p1, q1, p2, r2, q2, dp2, dr2, dq2)
+        else if (dr1 > 0.0f) TRI_TRI_3D(q1, r1, p1, p2, r2, q2, dp2, dr2, dq2)
+        else TRI_TRI_3D(p1, q1, r1, p2, q2, r2, dp2, dq2, dr2)
+    }
+    else if (dp1 < 0.0f) {
+        if (dq1 < 0.0f) TRI_TRI_3D(r1, p1, q1, p2, q2, r2, dp2, dq2, dr2)
+        else if (dr1 < 0.0f) TRI_TRI_3D(q1, r1, p1, p2, q2, r2, dp2, dq2, dr2)
+        else TRI_TRI_3D(p1, q1, r1, p2, r2, q2, dp2, dr2, dq2)
+    }
+    else {
+        if (dq1 < 0.0f) {
+            if (dr1 >= 0.0f) TRI_TRI_3D(q1, r1, p1, p2, r2, q2, dp2, dr2, dq2)
+            else TRI_TRI_3D(p1, q1, r1, p2, q2, r2, dp2, dq2, dr2)
+        }
+        else if (dq1 > 0.0f) {
+            if (dr1 > 0.0f) TRI_TRI_3D(p1, q1, r1, p2, r2, q2, dp2, dr2, dq2)
+            else TRI_TRI_3D(q1, r1, p1, p2, q2, r2, dp2, dq2, dr2)
+        }
+        else {
+            if (dr1 > 0.0f) TRI_TRI_3D(r1, p1, q1, p2, q2, r2, dp2, dq2, dr2)
+            else if (dr1 < 0.0f) TRI_TRI_3D(r1, p1, q1, p2, r2, q2, dp2, dr2, dq2)
+            else return coplanar_tri_tri3d(p1, q1, r1, p2, q2, r2, N1);
+        }
+    }
+};
+
+
+
+int coplanar_tri_tri3d(double p1[3], double q1[3], double r1[3],
+    double p2[3], double q2[3], double r2[3],
+    double normal_1[3]) {
+
+    double P1[2], Q1[2], R1[2];
+    double P2[2], Q2[2], R2[2];
+
+    double n_x, n_y, n_z;
+
+    n_x = ((normal_1[0] < 0) ? -normal_1[0] : normal_1[0]);
+    n_y = ((normal_1[1] < 0) ? -normal_1[1] : normal_1[1]);
+    n_z = ((normal_1[2] < 0) ? -normal_1[2] : normal_1[2]);
+
+
+    /* Projection of the triangles in 3D onto 2D such that the area of
+       the projection is maximized. */
+
+
+    if ((n_x > n_z) && (n_x >= n_y)) {
+        // Project onto plane YZ
+
+        P1[0] = q1[2]; P1[1] = q1[1];
+        Q1[0] = p1[2]; Q1[1] = p1[1];
+        R1[0] = r1[2]; R1[1] = r1[1];
+
+        P2[0] = q2[2]; P2[1] = q2[1];
+        Q2[0] = p2[2]; Q2[1] = p2[1];
+        R2[0] = r2[2]; R2[1] = r2[1];
+
+    }
+    else if ((n_y > n_z) && (n_y >= n_x)) {
+        // Project onto plane XZ
+
+        P1[0] = q1[0]; P1[1] = q1[2];
+        Q1[0] = p1[0]; Q1[1] = p1[2];
+        R1[0] = r1[0]; R1[1] = r1[2];
+
+        P2[0] = q2[0]; P2[1] = q2[2];
+        Q2[0] = p2[0]; Q2[1] = p2[2];
+        R2[0] = r2[0]; R2[1] = r2[2];
+
+    }
+    else {
+        // Project onto plane XY
+
+        P1[0] = p1[0]; P1[1] = p1[1];
+        Q1[0] = q1[0]; Q1[1] = q1[1];
+        R1[0] = r1[0]; R1[1] = r1[1];
+
+        P2[0] = p2[0]; P2[1] = p2[1];
+        Q2[0] = q2[0]; Q2[1] = q2[1];
+        R2[0] = r2[0]; R2[1] = r2[1];
+    }
+
+    return tri_tri_overlap_test_2d(P1, Q1, R1, P2, Q2, R2);
+
+};
+
+
+
+/*
+*
+*  Three-dimensional Triangle-Triangle Intersection
+*
+*/
+
+/*
+   This macro is called when the triangles surely intersect
+   It constructs the segment of intersection of the two triangles
+   if they are not coplanar.
+*/
+
+// NOTE: a faster, but possibly less precise, method of computing
+// point B is described here: https://github.com/erich666/jgt-code/issues/5
+
+#define CONSTRUCT_INTERSECTION(p1,q1,r1,p2,q2,r2) { \
+  SUB(v1,q1,p1) \
+  SUB(v2,r2,p1) \
+  CROSS(N,v1,v2) \
+  SUB(v,p2,p1) \
+  if (DOT(v,N) > 0.0f) {\
+    SUB(v1,r1,p1) \
+    CROSS(N,v1,v2) \
+    if (DOT(v,N) <= 0.0f) { \
+      SUB(v2,q2,p1) \
+      CROSS(N,v1,v2) \
+      if (DOT(v,N) > 0.0f) { \
+  SUB(v1,p1,p2) \
+  SUB(v2,p1,r1) \
+  alpha = DOT(v1,N2) / DOT(v2,N2); \
+  SCALAR(v1,alpha,v2) \
+  SUB(source,p1,v1) \
+  SUB(v1,p2,p1) \
+  SUB(v2,p2,r2) \
+  alpha = DOT(v1,N1) / DOT(v2,N1); \
+  SCALAR(v1,alpha,v2) \
+  SUB(target,p2,v1) \
+  return 1; \
+      } else { \
+  SUB(v1,p2,p1) \
+  SUB(v2,p2,q2) \
+  alpha = DOT(v1,N1) / DOT(v2,N1); \
+  SCALAR(v1,alpha,v2) \
+  SUB(source,p2,v1) \
+  SUB(v1,p2,p1) \
+  SUB(v2,p2,r2) \
+  alpha = DOT(v1,N1) / DOT(v2,N1); \
+  SCALAR(v1,alpha,v2) \
+  SUB(target,p2,v1) \
+  return 1; \
+      } \
+    } else { \
+      return 0; \
+    } \
+  } else { \
+    SUB(v2,q2,p1) \
+    CROSS(N,v1,v2) \
+    if (DOT(v,N) < 0.0f) { \
+      return 0; \
+    } else { \
+      SUB(v1,r1,p1) \
+      CROSS(N,v1,v2) \
+      if (DOT(v,N) >= 0.0f) { \
+  SUB(v1,p1,p2) \
+  SUB(v2,p1,r1) \
+  alpha = DOT(v1,N2) / DOT(v2,N2); \
+  SCALAR(v1,alpha,v2) \
+  SUB(source,p1,v1) \
+  SUB(v1,p1,p2) \
+  SUB(v2,p1,q1) \
+  alpha = DOT(v1,N2) / DOT(v2,N2); \
+  SCALAR(v1,alpha,v2) \
+  SUB(target,p1,v1) \
+  return 1; \
+      } else { \
+  SUB(v1,p2,p1) \
+  SUB(v2,p2,q2) \
+  alpha = DOT(v1,N1) / DOT(v2,N1); \
+  SCALAR(v1,alpha,v2) \
+  SUB(source,p2,v1) \
+  SUB(v1,p1,p2) \
+  SUB(v2,p1,q1) \
+  alpha = DOT(v1,N2) / DOT(v2,N2); \
+  SCALAR(v1,alpha,v2) \
+  SUB(target,p1,v1) \
+  return 1; \
+      }}}} 
+
+
+
+#define TRI_TRI_INTER_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2) { \
+  if (dp2 > 0.0f) { \
+     if (dq2 > 0.0f) CONSTRUCT_INTERSECTION(p1,r1,q1,r2,p2,q2) \
+     else if (dr2 > 0.0f) CONSTRUCT_INTERSECTION(p1,r1,q1,q2,r2,p2)\
+     else CONSTRUCT_INTERSECTION(p1,q1,r1,p2,q2,r2) }\
+  else if (dp2 < 0.0f) { \
+    if (dq2 < 0.0f) CONSTRUCT_INTERSECTION(p1,q1,r1,r2,p2,q2)\
+    else if (dr2 < 0.0f) CONSTRUCT_INTERSECTION(p1,q1,r1,q2,r2,p2)\
+    else CONSTRUCT_INTERSECTION(p1,r1,q1,p2,q2,r2)\
+  } else { \
+    if (dq2 < 0.0f) { \
+      if (dr2 >= 0.0f)  CONSTRUCT_INTERSECTION(p1,r1,q1,q2,r2,p2)\
+      else CONSTRUCT_INTERSECTION(p1,q1,r1,p2,q2,r2)\
+    } \
+    else if (dq2 > 0.0f) { \
+      if (dr2 > 0.0f) CONSTRUCT_INTERSECTION(p1,r1,q1,p2,q2,r2)\
+      else  CONSTRUCT_INTERSECTION(p1,q1,r1,q2,r2,p2)\
+    } \
+    else  { \
+      if (dr2 > 0.0f) CONSTRUCT_INTERSECTION(p1,q1,r1,r2,p2,q2)\
+      else if (dr2 < 0.0f) CONSTRUCT_INTERSECTION(p1,r1,q1,r2,p2,q2)\
+      else { \
+        *coplanar = 1; \
+  return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1);\
+     } \
+  }} }
+
+
+/*
+   The following version computes the segment of intersection of the
+   two triangles if it exists.
+   coplanar returns whether the triangles are coplanar
+   source and target are the endpoints of the line segment of intersection
+*/
+
+int tri_tri_intersection_test_3d(double p1[3], double q1[3], double r1[3],
+    double p2[3], double q2[3], double r2[3],
+    int* coplanar,
+    double source[3], double target[3])
+
+{
+    double dp1, dq1, dr1, dp2, dq2, dr2;
+    double v1[3], v2[3], v[3];
+    double N1[3], N2[3], N[3];
+    double alpha;
+
+    // Compute distance signs  of p1, q1 and r1 
+    // to the plane of triangle(p2,q2,r2)
+
+
+    SUB(v1, p2, r2)
+        SUB(v2, q2, r2)
+        CROSS(N2, v1, v2)
+
+        SUB(v1, p1, r2)
+        dp1 = DOT(v1, N2);
+    SUB(v1, q1, r2)
+        dq1 = DOT(v1, N2);
+    SUB(v1, r1, r2)
+        dr1 = DOT(v1, N2);
+
+    if (((dp1 * dq1) > 0.0f) && ((dp1 * dr1) > 0.0f))  return 0;
+
+    // Compute distance signs  of p2, q2 and r2 
+    // to the plane of triangle(p1,q1,r1)
+
+
+    SUB(v1, q1, p1)
+        SUB(v2, r1, p1)
+        CROSS(N1, v1, v2)
+
+        SUB(v1, p2, r1)
+        dp2 = DOT(v1, N1);
+    SUB(v1, q2, r1)
+        dq2 = DOT(v1, N1);
+    SUB(v1, r2, r1)
+        dr2 = DOT(v1, N1);
+
+    if (((dp2 * dq2) > 0.0f) && ((dp2 * dr2) > 0.0f)) return 0;
+
+    // Permutation in a canonical form of T1's vertices
+
+
+    if (dp1 > 0.0f) {
+        if (dq1 > 0.0f) TRI_TRI_INTER_3D(r1, p1, q1, p2, r2, q2, dp2, dr2, dq2)
+        else if (dr1 > 0.0f) TRI_TRI_INTER_3D(q1, r1, p1, p2, r2, q2, dp2, dr2, dq2)
+
+        else TRI_TRI_INTER_3D(p1, q1, r1, p2, q2, r2, dp2, dq2, dr2)
+    }
+    else if (dp1 < 0.0f) {
+        if (dq1 < 0.0f) TRI_TRI_INTER_3D(r1, p1, q1, p2, q2, r2, dp2, dq2, dr2)
+        else if (dr1 < 0.0f) TRI_TRI_INTER_3D(q1, r1, p1, p2, q2, r2, dp2, dq2, dr2)
+        else TRI_TRI_INTER_3D(p1, q1, r1, p2, r2, q2, dp2, dr2, dq2)
+    }
+    else {
+        if (dq1 < 0.0f) {
+            if (dr1 >= 0.0f) TRI_TRI_INTER_3D(q1, r1, p1, p2, r2, q2, dp2, dr2, dq2)
+            else TRI_TRI_INTER_3D(p1, q1, r1, p2, q2, r2, dp2, dq2, dr2)
+        }
+        else if (dq1 > 0.0f) {
+            if (dr1 > 0.0f) TRI_TRI_INTER_3D(p1, q1, r1, p2, r2, q2, dp2, dr2, dq2)
+            else TRI_TRI_INTER_3D(q1, r1, p1, p2, q2, r2, dp2, dq2, dr2)
+        }
+        else {
+            if (dr1 > 0.0f) TRI_TRI_INTER_3D(r1, p1, q1, p2, q2, r2, dp2, dq2, dr2)
+            else if (dr1 < 0.0f) TRI_TRI_INTER_3D(r1, p1, q1, p2, r2, q2, dp2, dr2, dq2)
+            else {
+                // triangles are co-planar
+
+                *coplanar = 1;
+                return coplanar_tri_tri3d(p1, q1, r1, p2, q2, r2, N1);
+            }
+        }
+    }
+};
+
+
+
+
+
+/*
+*
+*  Two dimensional Triangle-Triangle Overlap Test
+*
+*/
+
+
+/* some 2D macros */
+
+#define ORIENT_2D(a, b, c)  ((a[0]-c[0])*(b[1]-c[1])-(a[1]-c[1])*(b[0]-c[0]))
+
+
+#define INTERSECTION_TEST_VERTEX(P1, Q1, R1, P2, Q2, R2) {\
+  if (ORIENT_2D(R2,P2,Q1) >= 0.0f)\
+    if (ORIENT_2D(R2,Q2,Q1) <= 0.0f)\
+      if (ORIENT_2D(P1,P2,Q1) > 0.0f) {\
+  if (ORIENT_2D(P1,Q2,Q1) <= 0.0f) return 1; \
+  else return 0;} else {\
+  if (ORIENT_2D(P1,P2,R1) >= 0.0f)\
+    if (ORIENT_2D(Q1,R1,P2) >= 0.0f) return 1; \
+    else return 0;\
+  else return 0;}\
+    else \
+      if (ORIENT_2D(P1,Q2,Q1) <= 0.0f)\
+  if (ORIENT_2D(R2,Q2,R1) <= 0.0f)\
+    if (ORIENT_2D(Q1,R1,Q2) >= 0.0f) return 1; \
+    else return 0;\
+  else return 0;\
+      else return 0;\
+  else\
+    if (ORIENT_2D(R2,P2,R1) >= 0.0f) \
+      if (ORIENT_2D(Q1,R1,R2) >= 0.0f)\
+  if (ORIENT_2D(P1,P2,R1) >= 0.0f) return 1;\
+  else return 0;\
+      else \
+  if (ORIENT_2D(Q1,R1,Q2) >= 0.0f) {\
+    if (ORIENT_2D(R2,R1,Q2) >= 0.0f) return 1; \
+    else return 0; }\
+  else return 0; \
+    else  return 0; \
+ };
+
+
+
+#define INTERSECTION_TEST_EDGE(P1, Q1, R1, P2, Q2, R2) { \
+  if (ORIENT_2D(R2,P2,Q1) >= 0.0f) {\
+    if (ORIENT_2D(P1,P2,Q1) >= 0.0f) { \
+        if (ORIENT_2D(P1,Q1,R2) >= 0.0f) return 1; \
+        else return 0;} else { \
+      if (ORIENT_2D(Q1,R1,P2) >= 0.0f){ \
+  if (ORIENT_2D(R1,P1,P2) >= 0.0f) return 1; else return 0;} \
+      else return 0; } \
+  } else {\
+    if (ORIENT_2D(R2,P2,R1) >= 0.0f) {\
+      if (ORIENT_2D(P1,P2,R1) >= 0.0f) {\
+  if (ORIENT_2D(P1,R1,R2) >= 0.0f) return 1;  \
+  else {\
+    if (ORIENT_2D(Q1,R1,R2) >= 0.0f) return 1; else return 0;}}\
+      else  return 0; }\
+    else return 0; }}
+
+
+
+int ccw_tri_tri_intersection_2d(double p1[2], double q1[2], double r1[2],
+    double p2[2], double q2[2], double r2[2]) {
+    if (ORIENT_2D(p2, q2, p1) >= 0.0f) {
+        if (ORIENT_2D(q2, r2, p1) >= 0.0f) {
+            if (ORIENT_2D(r2, p2, p1) >= 0.0f) return 1;
+            else INTERSECTION_TEST_EDGE(p1, q1, r1, p2, q2, r2)
+        }
+        else {
+            if (ORIENT_2D(r2, p2, p1) >= 0.0f)
+                INTERSECTION_TEST_EDGE(p1, q1, r1, r2, p2, q2)
+            else INTERSECTION_TEST_VERTEX(p1, q1, r1, p2, q2, r2)
+        }
+    }
+    else {
+        if (ORIENT_2D(q2, r2, p1) >= 0.0f) {
+            if (ORIENT_2D(r2, p2, p1) >= 0.0f)
+                INTERSECTION_TEST_EDGE(p1, q1, r1, q2, r2, p2)
+            else  INTERSECTION_TEST_VERTEX(p1, q1, r1, q2, r2, p2)
+        }
+        else INTERSECTION_TEST_VERTEX(p1, q1, r1, r2, p2, q2)
+    }
+};
+
+
+int tri_tri_overlap_test_2d(double p1[2], double q1[2], double r1[2],
+    double p2[2], double q2[2], double r2[2]) {
+    if (ORIENT_2D(p1, q1, r1) < 0.0f)
+        if (ORIENT_2D(p2, q2, r2) < 0.0f)
+            return ccw_tri_tri_intersection_2d(p1, r1, q1, p2, r2, q2);
+        else
+            return ccw_tri_tri_intersection_2d(p1, r1, q1, p2, q2, r2);
+    else
+        if (ORIENT_2D(p2, q2, r2) < 0.0f)
+            return ccw_tri_tri_intersection_2d(p1, q1, r1, p2, r2, q2);
+        else
+            return ccw_tri_tri_intersection_2d(p1, q1, r1, p2, q2, r2);
+
+};


### PR DESCRIPTION
The goal of this PR is to add a self-intersection test to fcpw.
This PR is work in progress, I am mainly opening it to get some feedback and discuss some possible design decisions.
The main questions I have are:

- What triangle-triangle intersection algorithm should be used? At the moment I just copied a c implementation which is based on "Fast and Robust Triangle-Triangle Overlap Test Using Orientation Predicates"  P. Guigue - O. Devillers
If this choice is fine, then I would adapt the c implementation to fit better into the project.
- I have a couple of tests which I have not added to the PR yet, because the current test targets need some additional (pretty heavy, polyscope pulls in like 5 other transitive repositories) dependencies, which have to be added manually if I am not mistaken. How should I best proceed here? 
- How should touching triangles be handled? The current intersection algorithm yields a positive result if two triangles share a vertex. Thus, at the moment any two triangles which share a vertex are considered non-intersecting. This is probably not ideal, not sure about this. Intuitively, I'd say that e.g. a non-indexed cube should not be reported as intersecting, while e.g. two triangles which have a common vertex and intersecting in the interior should be reported as intersecting.
- What about other primitives? At the moment I throw an exception if the PrimitiveType is not a triangle, that's probably not ideal. 
- As currently implemented, the Aggregate base class does not contain any information about the tree structure, so I could not find a way how to implement the test for all the different Aggregate implementations. 
